### PR TITLE
Fix undefined behavior in SScalar::eval() due to cross-container iterator comparison

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -2091,7 +2091,7 @@ namespace hyperjet
             {
                 const auto it = d.find(coef.first);
 
-                if (it == m_d.end())
+                if (it == d.end())
                     continue;
 
                 r += coef.second * it->second;


### PR DESCRIPTION
Fixes a bug in `SScalar::eval()` where an iterator obtained from the parameter map `d` was compared against `m_d.end()` (the member map's end sentinel). Comparing iterators from different `std::unordered_map` instances is undefined behavior per the C++ standard.