### PR TITLE
Fix SScalar::eval() returning incorrect result (missing function value)

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -2085,7 +2085,7 @@ namespace hyperjet
 
         Scalar eval(const Data d) const
         {
-            Scalar r(0);
+            Scalar r(m_f);
 
             for (const auto coef : m_d)
             {


### PR DESCRIPTION
`SScalar::eval()` computed only the gradient dot product (∇f · δx) but omitted
the function value `m_f`, returning an incorrect result.