### PR TITLE
Fix avoid unnecessary map copy in SScalar::eval()

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -2083,7 +2083,7 @@ namespace hyperjet
             return it->second;
         }
 
-        Scalar eval(const Data d) const
+        Scalar eval(const Data& d) const
         {
             Scalar r(0);
 


### PR DESCRIPTION
`SScalar::eval()` accepted its `Data` parameter (an `std::unordered_map`) by
value, causing a full copy of the map on every call. Changed the signature from
`Scalar eval(const Data d) const` to `Scalar eval(const Data& d) const` to
pass by const reference instead.