### PR TITLE
Fix redundant hash lookup in SScalar::operator*=

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -2271,7 +2271,7 @@ namespace hyperjet
             m_f *= b;
 
             for (auto &d : m_d)
-                m_d[d.first] *= b;
+                d.second *= b;
 
             return *this;
         }


### PR DESCRIPTION
When iterating over m_d with a range-based for loop, each d is already a reference to a std::pair<const std::string, TScalar> entry in the map. The previous code m_d[d.first] *= b re-hashed the key to look up the same entry we already hold a reference to. This has been simplified to d.second *= b, which avoids the O(1)-amortized but unnecessary hash lookup on every iteration.