### PR TITLE
fix: restrict Hessian API to second-order DDScalar

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Static variants (`D1Scalar`–`D15Scalar`, `DD1Scalar`–`DD15Scalar`) avoid hea
 
 The convenience function `hj.variables(values, order=2)` automatically selects the appropriate static type when the number of variables is ≤ 15, and falls back to the dynamic variant otherwise.
 
+First-order types store only a value and a gradient. The Hessian accessors (`h`, `set_h`, `hm`, `set_hm`) therefore exist on second-order types only — in C++ they are constrained via `requires (order() == 2)`, and in Python they are absent from first-order classes.
+
 ### `SScalar` — Sparse dual numbers with named variables
 
 Stores first-order derivatives in a sparse map keyed by variable name (string). Useful when variables are identified by name rather than index, or when only a small subset of derivatives is non-zero.

--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -576,15 +576,23 @@ public:
 
   void set_g(const index i, const Scalar value) { g(i) = value; }
 
-  auto &h(this auto &self, const index i) {
+  auto &h(this auto &self, const index i)
+    requires(order() == 2)
+  {
     assert(0 <= i && i < self.size() * (self.size() + 1) / 2);
 
     return self.m_data[1 + self.size() + i];
   }
 
-  void set_h(const index i, const Scalar value) { h(i) = value; }
+  void set_h(const index i, const Scalar value)
+    requires(order() == 2)
+  {
+    h(i) = value;
+  }
 
-  auto &h(this auto &self, const index i, const index j) {
+  auto &h(this auto &self, const index i, const index j)
+    requires(order() == 2)
+  {
     assert(0 <= i && i < self.size());
     assert(0 <= j && j < self.size());
 
@@ -597,7 +605,9 @@ public:
     }
   }
 
-  void set_h(const index i, const index j, const Scalar value) {
+  void set_h(const index i, const index j, const Scalar value)
+    requires(order() == 2)
+  {
     h(i, j) = value;
   }
 
@@ -612,7 +622,9 @@ public:
 
   Eigen::Ref<Vector> ag() { return Eigen::Map<Vector>(ptr() + 1, size()); }
 
-  Matrix hm(const std::string mode) const {
+  Matrix hm(const std::string mode) const
+    requires(order() == 2)
+  {
     Matrix result(size(), size());
 
     hm(mode, result);
@@ -620,7 +632,9 @@ public:
     return result;
   }
 
-  void hm(const std::string mode, Eigen::Ref<Matrix> out) const {
+  void hm(const std::string mode, Eigen::Ref<Matrix> out) const
+    requires(order() == 2)
+  {
     index it = 0;
 
     for (index i = 0; i < size(); i++) {
@@ -646,7 +660,9 @@ public:
     }
   }
 
-  void set_hm(const Eigen::Ref<const Matrix> &value) {
+  void set_hm(const Eigen::Ref<const Matrix> &value)
+    requires(order() == 2)
+  {
     index it = 0;
 
     for (index i = 0; i < size(); i++) {

--- a/python/src/common.h
+++ b/python/src/common.h
@@ -92,19 +92,23 @@ template <typename T> auto bind(py::module &m, const std::string &name) {
       .def("__pow__", &T::pow)
       .def("__repr__", &T::to_string)
       .def("abs", &T::abs)
-      .def("eval", &T::eval, "d"_a)
-      .def(
-          "h",
-          [](const T &self, hj::index row, hj::index col) ->
-          typename T::Scalar { return self.h(row, col); },
-          "row"_a, "col"_a)
-      .def("set_h",
-           py::overload_cast<hj::index, hj::index, typename T::Scalar>(
-               &T::set_h),
-           "row"_a, "col"_a, "value"_a)
-      .def("hm", py::overload_cast<std::string>(&T::hm, py::const_),
-           "mode"_a = "full")
-      .def("set_hm", &T::set_hm, "value"_a);
+      .def("eval", &T::eval, "d"_a);
+
+  // methods: Hessian (second order only)
+  if constexpr (T::order() == 2) {
+    cls.def(
+           "h",
+           [](const T &self, hj::index row, hj::index col) ->
+           typename T::Scalar { return self.h(row, col); },
+           "row"_a, "col"_a)
+        .def("set_h",
+             py::overload_cast<hj::index, hj::index, typename T::Scalar>(
+                 &T::set_h),
+             "row"_a, "col"_a, "value"_a)
+        .def("hm", py::overload_cast<std::string>(&T::hm, py::const_),
+             "mode"_a = "full")
+        .def("set_hm", &T::set_hm, "value"_a);
+  }
 
   if constexpr (T::is_dynamic()) {
     cls.def("resize", &T::resize, "size"_a)

--- a/python/tests/test_DDScalar.py
+++ b/python/tests/test_DDScalar.py
@@ -543,6 +543,28 @@ def test_ndarray(ctx):
     ctx.check(u, [3, 4, 5, 6, 7, 8])
 
 
+@pytest.mark.parametrize("ctx", **test_data)
+def test_hessian_access(ctx):
+    u = ctx.from_data([1, 2, 3, 4, 5, 6])
+
+    if ctx.dtype.order == 2:
+        assert_equal(u.h(0, 0), 4)
+        assert_equal(u.hm(), [[4, 5], [5, 6]])
+        return
+
+    with pytest.raises(AttributeError):
+        u.h(0, 0)
+
+    with pytest.raises(AttributeError):
+        u.set_h(0, 0, 1)
+
+    with pytest.raises(AttributeError):
+        u.hm()
+
+    with pytest.raises(AttributeError):
+        u.set_hm([[1, 0], [0, 1]])
+
+
 def test_is_dynamic():
     assert_equal(static_set_2.u1.is_dynamic, False)
     assert_equal(dynamic_set_2.u1.is_dynamic, True)
@@ -1218,6 +1240,16 @@ def test_dd(ctx):
     dd = hj.dd(v)
 
     assert_equal(dd, v.hm())
+
+
+@pytest.mark.parametrize("ctx", **test_data)
+def test_dd_of_first_order(ctx):
+    if ctx.dtype.order == 2:
+        return
+
+    u = [ctx.u1, ctx.u2]
+
+    assert_equal(hj.dd(u), np.empty((2, 0, 0)))
 
 
 def test_f_of_scalar():

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -473,6 +473,53 @@ TEST_CASE("Norm") {
   REQUIRE(r.h(2, 2) == doctest::Approx(9.2320222391647280));
 }
 
+// The Hessian accessors index into m_data behind the gradient. First-order
+// scalars have no such storage, so the accessors must not exist for them.
+
+template <typename T>
+concept HasHessianEntry = requires(T a) { a.h(hyperjet::index(0)); };
+
+template <typename T>
+concept HasHessianElement =
+    requires(T a) { a.h(hyperjet::index(0), hyperjet::index(0)); };
+
+template <typename T>
+concept HasSetHessianEntry =
+    requires(T a) { a.set_h(hyperjet::index(0), typename T::Scalar(0)); };
+
+template <typename T>
+concept HasSetHessianElement = requires(T a) {
+  a.set_h(hyperjet::index(0), hyperjet::index(0), typename T::Scalar(0));
+};
+
+template <typename T>
+concept HasHessianMatrix = requires(const T a) { a.hm(std::string("full")); };
+
+template <typename T>
+concept HasSetHessianMatrix = requires(T a) { a.set_hm(typename T::Matrix()); };
+
+TEST_CASE("Hessian access is restricted to second order") {
+  CHECK(HasHessianEntry<DDScalar<2, double, 3>>);
+  CHECK(HasHessianElement<DDScalar<2, double, 3>>);
+  CHECK(HasSetHessianEntry<DDScalar<2, double, 3>>);
+  CHECK(HasSetHessianElement<DDScalar<2, double, 3>>);
+  CHECK(HasHessianMatrix<DDScalar<2, double, 3>>);
+  CHECK(HasSetHessianMatrix<DDScalar<2, double, 3>>);
+
+  CHECK(HasHessianElement<DDScalar<2, double, Dynamic>>);
+  CHECK(HasHessianMatrix<DDScalar<2, double, Dynamic>>);
+
+  CHECK_FALSE(HasHessianEntry<DDScalar<1, double, 3>>);
+  CHECK_FALSE(HasHessianElement<DDScalar<1, double, 3>>);
+  CHECK_FALSE(HasSetHessianEntry<DDScalar<1, double, 3>>);
+  CHECK_FALSE(HasSetHessianElement<DDScalar<1, double, 3>>);
+  CHECK_FALSE(HasHessianMatrix<DDScalar<1, double, 3>>);
+  CHECK_FALSE(HasSetHessianMatrix<DDScalar<1, double, 3>>);
+
+  CHECK_FALSE(HasHessianElement<DDScalar<1, double, Dynamic>>);
+  CHECK_FALSE(HasHessianMatrix<DDScalar<1, double, Dynamic>>);
+}
+
 const SScalar<double> s1(3.0, {{"x", 1.0}, {"y", 6.0}, {"z", 4.0}});
 const SScalar<double> s2(4.0, {{"x", 7.0}, {"y", 1.0}});
 const SScalar<double> s3(0.3, {{"x", 0.1}, {"y", 0.8}, {"z", 0.2}});


### PR DESCRIPTION
## Problem

The Hessian accessors index into `m_data` *behind* the gradient block:

```cpp
return self.m_data[1 + self.size() + i];
```

A first-order scalar has no such storage — its data length is `1 + size`. The header exposed `h` / `set_h` / `hm` / `set_hm` unconditionally, and `common.h` bound them for both orders (only `from_gradient`/`from_arrays` were guarded by order). So every Hessian access on a first-order type read or wrote past the end of the object, reachable from pure Python:

```python
v = hj.D3Scalar.variable(0, 1.0)   # data length 4
v.hm()
# [[0.00e+000, 5.83e-320, 9.88e-324],
#  [5.83e-320, 2.57e+151, 1.06e-153],   <- foreign memory
#  [9.88e-324, 1.06e-153, 8.19e+247]]

hj.DScalar.variable(0, 1.0, 3).set_hm(np.full((3, 3), 7.0))
# writes 6 doubles past a 4-element heap buffer, no error
```

The `assert`s in `h()` are compiled out in release wheels, so nothing caught it.

It also surfaced through the documented API: `hj.dd()` probes `hasattr(v, 'hm')` (`main.cpp:69`) and therefore returned foreign memory for first-order values instead of an empty Hessian.

## Fix

- **Header** — `requires (order() == 2)` on `h(i)`, `h(i, j)`, `set_h(i, v)`, `set_h(i, j, v)`, `hm(mode)`, `hm(mode, out)`, `set_hm(value)`.
- **Bindings** — the four `def`s moved under `if constexpr (T::order() == 2)`.

Putting the constraint on the header is what makes the guarantee: the binding can no longer drift away from it, and misuse in C++ becomes a compile error instead of silent UB. It also replaces one more `static_assert`-style guard with a real constraint (cf. `TODO.md` → *Concepts*).

## Tests

Both were written first and observed failing.

**C++** (`test/src/test.cpp`) — concepts probe the constraint directly at the header level, independent of the bindings. Before the fix all 8 first-order checks reported `true`:

```
test.cpp:513: ERROR: CHECK_FALSE( HasHessianEntry<DDScalar<1, double, 3>> ) is NOT correct!
  values: CHECK_FALSE( true )
... 8 failures
```

**Python** (`python/tests/test_DDScalar.py`) — `test_hessian_access` asserts `AttributeError` for first-order types (matching the existing `test_pad_right` convention) and keeps asserting real values for second order; `test_dd_of_first_order` pins `hj.dd()` to `np.empty((n, 0, 0))`, consistent with `test_dd_of_scalar`. The `hj.dd` failure showed the leak plainly:

```
(shapes (2, 2, 2), (2, 0, 0) mismatch)
 ACTUAL: array([[[ 0.      ,  1.414214],    <- u2's value, from the neighbouring object
        [ 1.414214, -0.353553]], ...
```

After: **C++ 40/40 test cases, 400 assertions** · **Python 147 passed** · `clang-format --Werror` and `ruff format --check` clean.

Second-order behaviour is unchanged — the existing `test_values` / `test_ndarray` / `test_dd` assertions on `h`, `set_h`, `hm`, `set_hm` all still pass untouched.

## Note

Found while reviewing the whole project. Related follow-ups, in rough order of severity, that this PR deliberately does *not* touch:

- `h(i, j)` / `set_h(i, j, v)` are still unbounded in release builds — `v.h(-5, -5)` reads arbitrary memory from Python. The binding layer needs a real range check; `assert` is the wrong mechanism at a language boundary.
- `DDScalar<1, double, Dynamic>{1.0, 2.0, 3.0}` segfaults (`m_data` is an empty vector when `std::copy` writes into it).
- `x *= x` and `x /= x` produce wrong derivatives (self-aliasing) in both `DDScalar` and `SScalar`.
- `resize()` silently scrambles the Hessian layout for order 2; `pad_right()` does it correctly.
