### PR TITLE
fix: size the storage in the initializer list constructor

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -311,7 +311,13 @@ public:
       : m_size(size_from_data_length(length(data))) {
     static_assert(0 < order() && order() <= 2);
 
-    std::copy(data.begin(), data.end(), m_data.begin());
+    check_valid_size(m_size);
+
+    if constexpr (is_dynamic()) {
+      m_data.assign(data.begin(), data.end());
+    } else {
+      std::copy(data.begin(), data.end(), m_data.begin());
+    }
   }
 
   static constexpr index order() { return TOrder; }

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -22,6 +22,44 @@ const DDScalar<2, double, 3> dd3{0.3, 0.1, 0.8, 0.2, 0.5,
 const Eigen::Matrix<DDScalar<2, double, 3>, 1, 3> ddv1{dd1, dd2, dd3};
 const Eigen::Matrix<DDScalar<2, double, 3>, 1, 3> ddv2{dd3, dd1, dd2};
 
+// The size of a scalar follows from the length of its data. For static types
+// that length is fixed by the type, so a mismatch has to be rejected.
+
+TEST_CASE("Initializer list construction") {
+  const DDScalar<2, double, Dynamic> a{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+
+  CHECK(a.size() == 2);
+  CHECK(a.data_length() == 6);
+  CHECK(a.f() == doctest::Approx(1.0));
+  CHECK(a.g(0) == doctest::Approx(2.0));
+  CHECK(a.g(1) == doctest::Approx(3.0));
+  CHECK(a.h(0, 0) == doctest::Approx(4.0));
+  CHECK(a.h(0, 1) == doctest::Approx(5.0));
+  CHECK(a.h(1, 1) == doctest::Approx(6.0));
+
+  const DDScalar<1, double, Dynamic> b{1.0, 2.0, 3.0};
+
+  CHECK(b.size() == 2);
+  CHECK(b.data_length() == 3);
+  CHECK(b.g(1) == doctest::Approx(3.0));
+
+  CHECK_NOTHROW((DDScalar<2, double, 3>{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+                                        9.0, 10.0}));
+
+  // a shorter triangular length leaves the data partially uninitialized
+  CHECK_THROWS_AS((DDScalar<2, double, 3>{1.0, 2.0, 3.0}), std::runtime_error);
+
+  // a longer one writes past the end of the array
+  CHECK_THROWS_AS(
+      (DDScalar<2, double, 3>{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+                              11.0, 12.0, 13.0, 14.0, 15.0}),
+      std::runtime_error);
+
+  // a length that is not triangular at all was already rejected
+  CHECK_THROWS_AS((DDScalar<2, double, 3>{1.0, 2.0, 3.0, 4.0, 5.0}),
+                  std::runtime_error);
+}
+
 TEST_CASE("<< DD") {
   std::stringstream output;
 


### PR DESCRIPTION
## Problem

```cpp
DDScalar(std::initializer_list<TScalar> data)
    : m_size(size_from_data_length(length(data))) {
  std::copy(data.begin(), data.end(), m_data.begin());
}
```

`m_size` is derived from the length of the data, but `m_data` is never sized — and the length is validated only against `size_from_data_length`, which accepts *any* triangular length, not the one the type actually requires. Three ways to break it, all confirmed under AddressSanitizer:

```cpp
DDScalar<2, double, Dynamic>{1, 2, 3, 4, 5, 6}
// AddressSanitizer: SEGV on unknown address 0x000000000000
//   #7 DDScalar<2l, double, -1l>::DDScalar(std::initializer_list<double>) hyperjet.h:314
// m_data is an empty vector when std::copy writes into it

DDScalar<2, double, 3>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
// AddressSanitizer: stack-buffer-overflow
// 15 doubles copied into a std::array<double, 10>

DDScalar<2, double, 3>{1, 2, 3}
// static(3) f=1.000000 size=3 h(2,2)=3.26066e-314
// silently constructed, 7 of 10 slots uninitialized, and size() reports 3
// while m_size is 1
```

The two static cases get past `size_from_data_length` because 15 and 3 *are* valid triangular lengths — for size 4 and size 1 respectively. They are simply not valid for size 3, and nothing compared them against `TSize`.

In a release build the dynamic case traps immediately (`exit 133`); under ASan it is a null write.

## Fix

```cpp
check_valid_size(m_size);

if constexpr (is_dynamic()) {
  m_data.assign(data.begin(), data.end());
} else {
  std::copy(data.begin(), data.end(), m_data.begin());
}
```

`check_valid_size` already exists and does exactly the right thing per variant: compare against `TSize` for static types, reject a negative size for dynamic ones. `assign` sizes the vector from the data.

Making the dynamic variant *work* rather than constraining the constructor away seems right: deriving `m_size` from the data length only ever made sense for the dynamic variant — for static types `m_size` is unused, since `size()` returns `TSize` — so supporting it was clearly the intent.

## Tests

`TEST_CASE("Initializer list construction")`, written first. RED was the test binary dying with **exit 133 (SIGTRAP) and no doctest output at all**, because the dynamic construction on the first line trapped before anything could be reported.

Covered: the dynamic variant for order 1 and 2 (size, data length, and every value read back through `f`/`g`/`h`), the valid static length, both invalid-but-triangular static lengths, and a non-triangular length as a guard on the pre-existing check.

After: **C++ 41/41 test cases, 415 assertions in both Debug and Release** · **Python 147 passed** · `clang-format --Werror` and `ruff format --check` clean · all three cases re-verified under ASan — dynamic constructs correctly, both static mismatches throw `std::runtime_error: Invalid size`, no sanitizer reports.

The existing `dd1`/`dd2`/`dd3` globals in `test.cpp` and `benchmarks.cpp` use exactly 10 elements for `DDScalar<2, double, 3>`, so they exercise the valid path and would have failed had the length check been wrong.

## Notes

Not reachable from Python — the bindings construct from data via `create()`, which validated the length already.

Independent of #73 (still open); the two touch different parts of the header and merge in either order.

This is the third memory-safety bug in a row that an ASan/UBSan job would have caught before merge. That is item 7 on the review list and probably worth doing before the remaining fixes.

Still open from the review:

- `x *= x` and `x /= x` produce wrong derivatives (self-aliasing) in both `DDScalar` and `SScalar`.
- `resize()` silently scrambles the Hessian layout for order 2; `pad_right()` does it correctly.
