### PR TITLE
ci: add a sanitizer job and turn on compiler warnings

### DIFF
--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
@@ -53,3 +56,37 @@ jobs:
         run: |
           cd build
           ctest --build-config ${{ matrix.build-type }}
+
+  sanitizers:
+    name: sanitizers (clang, asan+ubsan)
+
+    runs-on: ubuntu-latest
+
+    env:
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+      ASAN_OPTIONS: detect_stack_use_after_return=1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: "**/cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-sanitizers-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+
+      # clang doubles as a second front-end next to GCC 14 and MSVC, so this
+      # job is also where -Werror is enforced.
+      - name: Configure
+        run: >
+          cmake -Stest -Bbuild -DCMAKE_BUILD_TYPE=Debug
+          -DHYPERJET_SANITIZE=ON -DHYPERJET_WERROR=ON
+        env:
+          CXX: clang++
+
+      - name: Build
+        run: cmake --build build -j4
+
+      - name: Test
+        run: |
+          cd build
+          ctest

--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <array>    // array
-#include <assert.h> // assert
+#include <algorithm> // copy, fill
+#include <array>     // array
+#include <assert.h>  // assert
 #include <cmath> // acos, acosh, asin, asinh, atan, atanh, atan2, cbrt, cos, cosh, exp, hypot, log, log2, log10, pow, sin, sinh, sqrt, tan, tanh
 #include <cstddef>          // ptrdiff_t
 #include <initializer_list> // initializer_list
 #include <ostream>          // ostream
 #include <sstream>          // stringstream
+#include <stdexcept>        // runtime_error
 #include <string>           // string
 #include <type_traits>      // conditional
 #include <unordered_map>    // unordered_map
@@ -301,7 +303,7 @@ public:
     static_assert(!is_dynamic());
   }
 
-  DDScalar(const Data &data, const index size) : m_data(data), m_size(size) {
+  DDScalar(const Data &data, const index size) : m_size(size), m_data(data) {
     static_assert(0 < order() && order() <= 2);
 
     static_assert(is_dynamic());
@@ -2089,7 +2091,6 @@ public: // methods
     using std::hypot;
 
     const auto f = hypot(a.m_f, b.m_f);
-    const auto f3 = f * f * f;
     const auto da = a.m_f / f;
     const auto db = b.m_f / f;
 
@@ -2100,11 +2101,6 @@ public: // methods
     using std::hypot;
 
     const auto f = hypot(a.m_f, b.m_f, c.m_f);
-
-    const auto f3 = f * f * f;
-    const auto a2 = a.m_f * a.m_f;
-    const auto b2 = b.m_f * b.m_f;
-    const auto c2 = c.m_f * c.m_f;
 
     const auto da = a.m_f / f;
     const auto db = b.m_f / f;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ CPMAddPackage(
 
 if(Eigen_ADDED)
   add_library(Eigen INTERFACE IMPORTED)
-  target_include_directories(Eigen INTERFACE ${Eigen_SOURCE_DIR})
+  target_include_directories(Eigen SYSTEM INTERFACE ${Eigen_SOURCE_DIR})
 endif()
 
 if(TEST_INSTALLED_VERSION)
@@ -32,6 +32,39 @@ file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 add_executable(HyperJetTest ${sources})
 target_link_libraries(HyperJetTest doctest::doctest hyperjet::hyperjet Eigen)
 set_target_properties(HyperJetTest PROPERTIES CXX_STANDARD 23)
+
+# --- Warnings
+
+# HYPERJET_WERROR is enabled by a single CI job. Warnings differ between
+# compilers, so promoting them to errors everywhere would let an unrelated
+# toolchain block every build.
+option(HYPERJET_WERROR "Treat compiler warnings as errors" OFF)
+
+if(MSVC)
+  target_compile_options(HyperJetTest PRIVATE /W4)
+
+  if(HYPERJET_WERROR)
+    target_compile_options(HyperJetTest PRIVATE /WX)
+  endif()
+else()
+  target_compile_options(HyperJetTest PRIVATE -Wall -Wextra -Wpedantic)
+
+  if(HYPERJET_WERROR)
+    target_compile_options(HyperJetTest PRIVATE -Werror)
+  endif()
+endif()
+
+# --- Sanitizers
+
+option(HYPERJET_SANITIZE "Build the tests with the address and undefined behavior sanitizers" OFF)
+
+if(HYPERJET_SANITIZE)
+  target_compile_options(
+    HyperJetTest PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+                         -fno-omit-frame-pointer -g
+  )
+  target_link_options(HyperJetTest PRIVATE -fsanitize=address,undefined)
+endif()
 
 # --- Add HyperJetTest
 

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -747,3 +747,22 @@ TEST_CASE("SScalar Tan") {
   REQUIRE(r1.d("y") == doctest::Approx(6.12191710165456100));
   REQUIRE(r1.d("z") == doctest::Approx(4.08127806776970700));
 }
+TEST_CASE("SScalar Hypot") {
+  using std::hypot;
+
+  const auto r1 = hypot(s1, s2);
+
+  REQUIRE(r1.size() == 3);
+  REQUIRE(r1.f() == doctest::Approx(5.0));
+  REQUIRE(r1.d("x") == doctest::Approx(6.2000000000000000));
+  REQUIRE(r1.d("y") == doctest::Approx(4.4000000000000000));
+  REQUIRE(r1.d("z") == doctest::Approx(2.4000000000000000));
+
+  const auto r2 = hypot(s1, s2, s3);
+
+  REQUIRE(r2.size() == 3);
+  REQUIRE(r2.f() == doctest::Approx(5.0089919145472770));
+  REQUIRE(r2.d("x") == doctest::Approx(6.1948592709606240));
+  REQUIRE(r2.d("y") == doctest::Approx(4.4400151526317840));
+  REQUIRE(r2.d("z") == doctest::Approx(2.4076700872634590));
+}


### PR DESCRIPTION
## Why

Three memory-safety bugs in a row (#72, #73, #74) were found by running the tests under AddressSanitizer by hand. This makes that part of CI.

## What

Two options on the test target, both off by default:

| Option | Effect |
|---|---|
| `HYPERJET_SANITIZE` | `-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer` — undefined behaviour aborts instead of printing and passing |
| `HYPERJET_WERROR` | promotes warnings to errors |

Warnings themselves (`-Wall -Wextra -Wpedantic`, `/W4`) are **always** on, so they show up locally too. Only the one new job fails on them: warning sets differ between compilers, and an unrelated toolchain should not be able to block every build.

The job runs both on **clang**, which also covers a third front-end next to GCC 14 and MSVC. Eigen and doctest are now included as `SYSTEM` headers so third-party warnings cannot fail our build. Added `permissions: contents: read` while in this file.

## The job is not decorative

Verified against a reproducer for the initializer-list bug that #74 fixes, which is still present on `main`:

```
test case CRASHED: SIGSEGV - Segmentation violation signal
==1413==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
    #7 hyperjet::DDScalar<2l, double, -1l>::DDScalar(std::initializer_list<double>) hyperjet.h:314
SUMMARY: AddressSanitizer: SEGV in __constexpr_memmove<double, double const>
```

Exit code 134, pointing at the exact line. The reproducer was removed again — it belongs to #74.

## Warnings this surfaced

- **`SScalar::hypot` kept `f3`, `a2`, `b2`, `c2`** from the `DDScalar` version, where they carry the second-order terms. `SScalar` is first order only, so they were dead code.
- **`DDScalar(const Data&, index)` initialized `m_data` before `m_size`** while the declaration order is the reverse (`-Wreorder-ctor`). Harmless today, because the vector constructor does not read `m_size` — but it is a warning inside a header shipped to users.

Neither warning appeared before this PR, and the reason matters: **nothing instantiated those functions.** The suite never touched `SScalar::hypot` or a dynamic `DDScalar`, and templates that are not instantiated are not compiled. A warnings job is only as good as the instantiation coverage.

So this also adds the missing `TEST_CASE("SScalar Hypot")` — genuinely absent coverage (both the 2- and 3-argument form), and what surfaced the dead variables in the first place. The dynamic constructor gets its coverage from the tests in #73; that is also why **#73 would have failed a `-Werror` build** before the reorder fix in this PR.

## Also included

`<algorithm>` (`std::copy`, `std::fill`) and `<stdexcept>` (`std::runtime_error`), which the header only ever got through transitive includes. Two lines, deliberately in scope: the new job compiles with a front-end the project has not built with before, and missing includes are exactly what breaks first under a new toolchain — I did not want the job's first result to be a failure for an unrelated reason.

## Verification

Ran the exact command chain the job runs, locally with clang:

```
cmake -Stest -Bbuild -DCMAKE_BUILD_TYPE=Debug -DHYPERJET_SANITIZE=ON -DHYPERJET_WERROR=ON
cmake --build build -j4
ctest        # 100% tests passed, 0 tests failed out of 41
```

- `-Werror` build clean in **Debug and Release**, 41 test cases / 410 assertions
- ASan+UBSan run over the full suite clean
- Python 147 passed, `clang-format --Werror` clean
- workflow YAML parses; both jobs and the sanitizer env resolve as intended

Not verifiable locally: the GCC 14 and MSVC warning sets (macOS has only Apple clang here). That is precisely why `-Werror` is scoped to the one clang job rather than the whole matrix.

## Notes

Independent of #73 and #74 — this branch is based on `main` and merges in any order. Note that after #73 and #74 merge, the new job covers strictly more, since both add dynamic-type tests.

Follow-ups from the review that this PR does *not* do:

- `permissions: contents: read` for the other three workflows.
- Coverage measurement.
- The parametrized `{order 1, 2} × {static, dynamic}` C++ test axis — the single biggest lever on what the sanitizer and warnings jobs can actually see.
