### PR TITLE
fix: handle aliased operands in the in-place operators

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -951,6 +951,11 @@ public:
   Type &operator*=(const Type &b) {
     check_equal_size(size(), b.size());
 
+    // aliased operands would be read again after being overwritten below
+    if (this == &b) {
+      return *this = *this * b;
+    }
+
     const Data a_m_data = m_data;
 
     const Scalar da = b.f();
@@ -1028,6 +1033,11 @@ public:
     using std::pow;
 
     check_equal_size(size(), b.size());
+
+    // aliased operands would be read again after being overwritten below
+    if (this == &b) {
+      return *this = *this / b;
+    }
 
     const Data a_m_data = m_data;
 
@@ -1947,6 +1957,11 @@ public: // methods
   friend Type operator*(const Scalar a, const Type &b) { return b * a; }
 
   Type &operator*=(const Type &b) {
+    // aliased operands would be read again after being overwritten below
+    if (this == &b) {
+      return *this = *this * b;
+    }
+
     const Scalar da = b.m_f;
     const Scalar db = m_f;
 
@@ -1997,6 +2012,11 @@ public: // methods
 
   Type &operator/=(const Type &b) {
     using std::pow;
+
+    // aliased operands would be read again after being overwritten below
+    if (this == &b) {
+      return *this = *this / b;
+    }
 
     const auto da = 1 / b.m_f;
     const auto db = -m_f / pow(b.m_f, 2);

--- a/python/tests/test_DDScalar.py
+++ b/python/tests/test_DDScalar.py
@@ -711,6 +711,25 @@ def test_pad_left(ctx):
             u.pad_left(new_size=5)
 
 
+@pytest.mark.parametrize("ctx", **test_data)
+def test_self_multiplication(ctx):
+    r = ctx.u1
+    r *= r
+
+    assert_allclose(r.data, (ctx.u1 * ctx.u1).data, atol=1e-16)
+
+
+@pytest.mark.parametrize("ctx", **test_data)
+def test_self_division(ctx):
+    r = ctx.u1
+    r /= r
+
+    expected = np.zeros(len(r.data))
+    expected[0] = 1
+
+    assert_allclose(r.data, expected, atol=1e-15)
+
+
 # serialization
 
 

--- a/python/tests/test_SScalar.py
+++ b/python/tests/test_SScalar.py
@@ -40,3 +40,28 @@ def test_mul():
     assert_allclose(r.d("x"), 1)
     assert_allclose(r.d("y"), 2)
     assert_allclose(r.d("z"), 0)
+
+
+def test_self_multiplication():
+    r = hj.SScalar(f=3, d={"x": 1, "y": 6})
+    r *= r
+
+    u = hj.SScalar(f=3, d={"x": 1, "y": 6})
+    e = u * hj.SScalar(f=3, d={"x": 1, "y": 6})
+
+    assert_allclose(r.f, e.f)
+    assert_allclose(r.d("x"), e.d("x"))
+    assert_allclose(r.d("y"), e.d("y"))
+
+    assert_allclose(r.f, 9)
+    assert_allclose(r.d("x"), 6)
+    assert_allclose(r.d("y"), 36)
+
+
+def test_self_division():
+    r = hj.SScalar(f=3, d={"x": 1, "y": 6})
+    r /= r
+
+    assert_allclose(r.f, 1)
+    assert_allclose(r.d("x"), 0, atol=1e-15)
+    assert_allclose(r.d("y"), 0, atol=1e-15)

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -287,6 +287,49 @@ TEST_CASE("IncDiv") {
   REQUIRE(r1.h(2, 2) == doctest::Approx(1.43750));
 }
 
+// An in-place operator has to give the same result as its binary counterpart,
+// including when both operands are the same object.
+
+TEST_CASE("Self multiplication") {
+  auto r1 = dd1;
+  r1 *= r1;
+
+  const auto r2 = dd1 * dd1;
+
+  REQUIRE(r1.f() == doctest::Approx(r2.f()));
+  REQUIRE(r1.g(0) == doctest::Approx(r2.g(0)));
+  REQUIRE(r1.g(1) == doctest::Approx(r2.g(1)));
+  REQUIRE(r1.g(2) == doctest::Approx(r2.g(2)));
+  REQUIRE(r1.h(0, 0) == doctest::Approx(r2.h(0, 0)));
+  REQUIRE(r1.h(0, 1) == doctest::Approx(r2.h(0, 1)));
+  REQUIRE(r1.h(0, 2) == doctest::Approx(r2.h(0, 2)));
+  REQUIRE(r1.h(1, 1) == doctest::Approx(r2.h(1, 1)));
+  REQUIRE(r1.h(1, 2) == doctest::Approx(r2.h(1, 2)));
+  REQUIRE(r1.h(2, 2) == doctest::Approx(r2.h(2, 2)));
+
+  // dd1 is 3 with g0 = 1 and h00 = 0, so x^2 gives 9, 2*x*g0 and 2*g0^2
+  REQUIRE(r1.f() == doctest::Approx(9.0));
+  REQUIRE(r1.g(0) == doctest::Approx(6.0));
+  REQUIRE(r1.h(0, 0) == doctest::Approx(2.0));
+}
+
+TEST_CASE("Self division") {
+  auto r1 = dd1;
+  r1 /= r1;
+
+  // x / x is 1 and all of its derivatives vanish
+  REQUIRE(r1.f() == doctest::Approx(1.0));
+  REQUIRE(r1.g(0) == doctest::Approx(0.0));
+  REQUIRE(r1.g(1) == doctest::Approx(0.0));
+  REQUIRE(r1.g(2) == doctest::Approx(0.0));
+  REQUIRE(r1.h(0, 0) == doctest::Approx(0.0));
+  REQUIRE(r1.h(0, 1) == doctest::Approx(0.0));
+  REQUIRE(r1.h(0, 2) == doctest::Approx(0.0));
+  REQUIRE(r1.h(1, 1) == doctest::Approx(0.0));
+  REQUIRE(r1.h(1, 2) == doctest::Approx(0.0));
+  REQUIRE(r1.h(2, 2) == doctest::Approx(0.0));
+}
+
 TEST_CASE("Pow") {
   using std::pow;
 
@@ -755,6 +798,34 @@ TEST_CASE("SScalar IncDiv") {
   REQUIRE(r1.d("x") == doctest::Approx(-1.06250));
   REQUIRE(r1.d("y") == doctest::Approx(1.31250));
   REQUIRE(r1.d("z") == doctest::Approx(1.00000));
+}
+
+TEST_CASE("SScalar Self multiplication") {
+  auto r1 = s1;
+  r1 *= r1;
+
+  const auto r2 = s1 * s1;
+
+  REQUIRE(r1.f() == doctest::Approx(r2.f()));
+  REQUIRE(r1.d("x") == doctest::Approx(r2.d("x")));
+  REQUIRE(r1.d("y") == doctest::Approx(r2.d("y")));
+  REQUIRE(r1.d("z") == doctest::Approx(r2.d("z")));
+
+  // s1 is 3 with dx = 1, dy = 6 and dz = 4
+  REQUIRE(r1.f() == doctest::Approx(9.0));
+  REQUIRE(r1.d("x") == doctest::Approx(6.0));
+  REQUIRE(r1.d("y") == doctest::Approx(36.0));
+  REQUIRE(r1.d("z") == doctest::Approx(24.0));
+}
+
+TEST_CASE("SScalar Self division") {
+  auto r1 = s1;
+  r1 /= r1;
+
+  REQUIRE(r1.f() == doctest::Approx(1.0));
+  REQUIRE(r1.d("x") == doctest::Approx(0.0));
+  REQUIRE(r1.d("y") == doctest::Approx(0.0));
+  REQUIRE(r1.d("z") == doctest::Approx(0.0));
 }
 
 TEST_CASE("SScalar Pow") {


### PR DESCRIPTION
## Problem

`x *= x` and `x /= x` compute derivatives from data they have already overwritten, because `b` and `*this` are the same storage:

| | mechanism |
|---|---|
| `DDScalar::operator*=` | the Hessian loop reads `b.m_data[1 + j]` after the gradient loop has replaced it |
| `DDScalar::operator/=` | `binary()` writes into `m_data`, which is also its `b` |
| `SScalar::operator*=` | the second loop reads `b.m_d` after the first has scaled it |
| `SScalar::operator/=` | same |

Measured on `x = 3` with `dx = 1`:

| | result | expected | |
|---|---|---|---|
| `DDScalar` `x *= x` | `h00 = 12` | `h00 = 2` | **wrong** |
| `DDScalar` `x /= x` | `0` | `0` | accidentally right |
| `SScalar` `x *= x` | `dx = 12` | `dx = 6` | **wrong** |
| `SScalar` `x /= x` | `dx = 0.222` | `dx = 0` | **wrong** |

Two corrections to what I claimed when filing this:

- **Only the second-order part of `DDScalar::operator*=` is affected.** The gradient loop reads `b.m_data[i]` in the same expression that writes it, so it still sees the original value and produces the correct `2·f·g`. That is why the first-order types come out right.
- **`DDScalar::operator/=` is not observably broken.** When both operands alias, the gradient loop zeroes every slot before the Hessian loop reads them — and the correct Hessian of `x / x` is zero as well, so the stale data happens to give the right answer. It is guarded anyway: that only holds because aliasing forces the trivial result, and a change to the loop order would break it silently.

`+=` and `-=` are correct in both classes and are left alone. They read and write the same element within one expression, which yields `2a` and `0` as it should.

## Fix

All four delegate to the binary operator, which builds a fresh result and therefore cannot read overwritten data:

```cpp
// aliased operands would be read again after being overwritten below
if (this == &b) {
  return *this = *this * b;
}
```

The extra copy only happens for the aliased call. Cost of the pointer comparison on the hot path — 2M iterations of `a *= b; a /= b`, `-O3 -DNDEBUG`, static order 2 size 8, three alternating runs:

| run | with guard | without |
|---|---|---|
| 1 | 177.3 ns/op | 178.5 ns/op |
| 2 | 177.0 ns/op | 175.8 ns/op |
| 3 | 179.5 ns/op | 174.2 ns/op |

Noise. Dynamic size 8 and 32 likewise (152.4 vs 152.2, 754.0 vs 758.3), with identical accumulated results.

## Tests

Written first. The oracle is the binary operator — the invariant being that in-place and binary agree — plus analytic anchors so the test cannot pass by both paths breaking the same way: `x²` at `x = 3` with `g0 = 1` has `f = 9`, `g0 = 6`, `h00 = 2`, and `x / x` is `1` with every derivative zero.

**C++** — `Self multiplication`, `Self division`, `SScalar Self multiplication`, `SScalar Self division`. RED:

```
test.cpp:303: FATAL ERROR: REQUIRE( r1.h(0, 0) == doctest::Approx(r2.h(0, 0)) ) is NOT correct!
test.cpp:810: FATAL ERROR: REQUIRE( r1.d("x") == doctest::Approx(r2.d("x")) ) is NOT correct!
test.cpp:826: FATAL ERROR: REQUIRE( r1.d("x") == doctest::Approx(0.0) ) is NOT correct!
```

**Python** — `test_self_multiplication` and `test_self_division` over all four `{order 1, 2} × {static, dynamic}` contexts, plus the two `SScalar` cases. RED failed on exactly the four combinations predicted above, which is what confirmed the two corrections: `test_self_multiplication` failed for 2nd order only, and `test_self_division` passed for all four `DDScalar` variants.

After: **C++ 46/46 test cases, 456 assertions** · **Python 176 passed** · `clang-format --Werror` and `ruff format --check` clean.

## Notes

Based on `main` with #73 and #74 merged. Independent of #75 (still open) — and once #75 lands, this code is covered by the sanitizer job as well.

Last item from the review's P0 list:

- `resize()` silently scrambles the Hessian layout for order 2 (`pad_right()` does it correctly). #73 only stopped it from accepting a negative size.
