### PR TITLE
fix: make the array overload of variables() deducible

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -578,12 +578,14 @@ public:
     return vars;
   }
 
-  template <index T>
+  // std::array is sized by std::size_t, so T has to be as well or the size
+  // can never be deduced from the argument.
+  template <std::size_t T>
   static std::conditional_t<TSize == Dynamic, std::vector<Type>,
                             std::array<Type, T>>
   variables(const std::array<Scalar, T> &values) {
     if constexpr (!is_dynamic()) {
-      static_assert(T == TSize);
+      static_assert(index(T) == TSize);
     }
 
     const index s = length(values);
@@ -595,7 +597,7 @@ public:
       }
       return vars;
     } else {
-      std::array<Type, TSize> vars;
+      std::array<Type, T> vars;
       for (index i = 0; i < s; i++) {
         vars[i] = variable(i, values[i], s);
       }

--- a/python/src/common.h
+++ b/python/src/common.h
@@ -93,7 +93,7 @@ template <typename T> auto bind(py::module &m, const std::string &name) {
         .def_static(
             "variables",
             [](const std::array<typename T::Scalar, T::static_size()> &values) {
-              return T::template variables<T::static_size()>(values);
+              return T::variables(values);
             },
             "values"_a);
   }

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -830,3 +830,43 @@ TEST_CASE("SScalar Hypot") {
   REQUIRE(r2.d("y") == doctest::Approx(4.4400151526317840));
   REQUIRE(r2.d("z") == doctest::Approx(2.4076700872634590));
 }
+
+// The C++ usage example from the README. Its values are pinned here so the
+// example cannot silently stop compiling or start lying.
+
+TEST_CASE("README example") {
+  auto [x, y] = DDScalar<2, double, 2>::variables(std::array{3.0, 6.0});
+
+  const auto f = (x * y) / (x - y);
+
+  REQUIRE(f.f() == doctest::Approx(-6.0));
+  REQUIRE(f.g(0) == doctest::Approx(-4.0));
+  REQUIRE(f.g(1) == doctest::Approx(1.0));
+
+  // the same computation as the Python quickstart, whose output the README
+  // shows as well
+  REQUIRE(f.h(0, 0) == doctest::Approx(-2.6666666666666667));
+  REQUIRE(f.h(0, 1) == doctest::Approx(1.3333333333333333));
+  REQUIRE(f.h(1, 1) == doctest::Approx(-0.6666666666666666));
+}
+
+TEST_CASE("Variables from an array") {
+  const auto s = DDScalar<2, double, 2>::variables(std::array{3.0, 6.0});
+
+  REQUIRE(s.size() == 2);
+  REQUIRE(s[0].f() == doctest::Approx(3.0));
+  REQUIRE(s[0].g(0) == doctest::Approx(1.0));
+  REQUIRE(s[0].g(1) == doctest::Approx(0.0));
+  REQUIRE(s[1].f() == doctest::Approx(6.0));
+  REQUIRE(s[1].g(0) == doctest::Approx(0.0));
+  REQUIRE(s[1].g(1) == doctest::Approx(1.0));
+
+  // the dynamic variant returns a vector, sized from the array
+  const auto d = DDScalar<2, double, Dynamic>::variables(std::array{3.0, 6.0});
+
+  REQUIRE(d.size() == 2);
+  REQUIRE(d[0].size() == 2);
+  REQUIRE(d[0].f() == doctest::Approx(3.0));
+  REQUIRE(d[0].g(0) == doctest::Approx(1.0));
+  REQUIRE(d[1].g(1) == doctest::Approx(1.0));
+}


### PR DESCRIPTION
## Problem

```cpp
template <index T>                                  // index = std::ptrdiff_t
static std::conditional_t<...> variables(const std::array<Scalar, T> &values)
```

`std::array` is sized by `std::size_t`, so deducing a `ptrdiff_t` non-type parameter from the argument always fails:

```
error: no matching function for call to 'variables'
note: candidate function not viable: no known conversion from 'std::array<double, 2>'
      to 'const std::vector<Scalar>' for 1st argument
note: candidate template ignored: substitution failure: deduced non-type template
      argument does not have the same type as the corresponding template parameter
      ('unsigned long' vs 'index' (aka 'long'))
```

**The C++ usage example in the README did not compile.** The overload was only ever reachable from the bindings, which passed the size explicitly and therefore never exercised deduction:

```cpp
T::template variables<T::static_size()>(values)
```

## Fix

Declare `T` as `std::size_t`. Three small consequences:

- The explicit workaround in `common.h` goes away — `T::variables(values)` now deduces.
- `static_assert(index(T) == TSize)` compares as `index`, so both sides keep the same signedness (relevant now that `-Wall -Wextra` is on since #75).
- The local array is sized by `T` instead of `TSize`, which the assert has just established to be equal, and avoids a signed→unsigned conversion in a template argument.

## Verification

The README snippet now compiles **verbatim**. Rather than retyping it, I extracted the ` ```cpp ` block straight out of `README.md` and built it with `-Wall -Wextra -Wpedantic -Werror`:

```
f   = -6
df/dx = -4
df/dy = 1
d²f/dx² = -2.66667
```

which is exactly what its inline comments claim.

- **C++ 45/45 test cases, 449 assertions** — Debug, Release, and the clang ASan+UBSan job, all with `-Werror`
- **Python 166 passed**; `D3Scalar.variables([1,2,3])` and `DDScalar.variables([1,2])` verified to still produce the right gradients through the simplified binding
- `clang-format --Werror` and `ruff format --check` clean

## Tests

`TEST_CASE("README example")` pins the example's values, so it cannot silently stop compiling or start lying again. Its Hessian is the same computation the **Python quickstart** shows in the README (`[[-2.667, 1.333], [1.333, -0.667]]`), so those numbers are covered by the same test.

`TEST_CASE("Variables from an array")` exercises both branches of the conditional return type — `std::array<Type, T>` for static and `std::vector<Type>` for dynamic. Neither had any C++ coverage before, which is how the deduction failure survived: the only caller passed the size explicitly.

## Notes

A durable version of the README check would extract and compile the snippets in CI rather than duplicating them in a test. Worth doing once there are more of them; the pinned test case covers this one.

Based on `main` with #75 merged. Independent of #76 and #77 (both still open).
