### PR TITLE
refactor: drop the runtime size from statically sized scalars

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -18,8 +18,10 @@ namespace hyperjet {
 
 #if defined(_MSC_VER)
 #define HYPERJET_INLINE __forceinline
+#define HYPERJET_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
 #define HYPERJET_INLINE __attribute__((always_inline)) inline
+#define HYPERJET_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
 using index = std::ptrdiff_t;
@@ -47,13 +49,19 @@ class DDScalar {
   using DynamicStorage = std::vector<TScalar>;
   using StaticStorage = std::array<TScalar, StaticDataSize>;
 
+  // A statically sized scalar knows its size from TSize, so it carries no
+  // field for it. The empty stand-in keeps m_size spellable in both variants.
+  struct NoSize {};
+
 public:
   using Type = DDScalar<TOrder, TScalar, TSize>;
   using Scalar = TScalar;
   using Data = typename std::conditional<TSize == Dynamic, DynamicStorage,
                                          StaticStorage>::type;
 
-  index m_size;
+  using SizeStorage = std::conditional_t<TSize == Dynamic, index, NoSize>;
+
+  HYPERJET_NO_UNIQUE_ADDRESS SizeStorage m_size;
   Data m_data;
 
 public:
@@ -331,13 +339,15 @@ public:
     static_assert(is_dynamic());
   }
 
-  DDScalar(std::initializer_list<TScalar> data)
-      : m_size(size_from_data_length(length(data))) {
+  DDScalar(std::initializer_list<TScalar> data) {
     static_assert(0 < order() && order() <= 2);
 
-    check_valid_size(m_size);
+    const index s = size_from_data_length(length(data));
+
+    check_valid_size(s);
 
     if constexpr (is_dynamic()) {
+      m_size = s;
       m_data.assign(data.begin(), data.end());
     } else {
       std::copy(data.begin(), data.end(), m_data.begin());

--- a/test/src/test_variants.cpp
+++ b/test/src/test_variants.cpp
@@ -4,8 +4,9 @@
 
 #include <hyperjet/hyperjet.h>
 
-#include <array>  // array
-#include <vector> // vector
+#include <array>       // array
+#include <type_traits> // is_trivially_copyable
+#include <vector>      // vector
 
 // Coverage across all four combinations of order and sizing.
 //
@@ -104,6 +105,23 @@ void check(const T &actual, const std::vector<double> &expected) {
   for (index i = 0; i < n; i++) {
     CHECK(actual.data()[i] == doctest::Approx(expected[i]));
   }
+}
+
+// A statically sized scalar is exactly its data. The runtime size is only
+// meaningful for the dynamic variant, where it also rules out trivial copying.
+// Both properties are what an element type has to offer a NumPy dtype.
+
+TEST_CASE("Static scalars are exactly their data") {
+  CHECK(sizeof(DDScalar<1, double, 0>) == sizeof(DDScalar<1, double, 0>::Data));
+  CHECK(sizeof(DDScalar<1, double, 3>) == sizeof(DDScalar<1, double, 3>::Data));
+  CHECK(sizeof(DDScalar<2, double, 3>) == sizeof(DDScalar<2, double, 3>::Data));
+  CHECK(sizeof(DDScalar<2, double, 8>) == sizeof(DDScalar<2, double, 8>::Data));
+
+  CHECK(std::is_trivially_copyable_v<DDScalar<1, double, 3>>);
+  CHECK(std::is_trivially_copyable_v<DDScalar<2, double, 3>>);
+  CHECK(std::is_standard_layout_v<DDScalar<2, double, 3>>);
+
+  CHECK_FALSE(std::is_trivially_copyable_v<DDScalar<2, double, Dynamic>>);
 }
 
 TEST_CASE_TEMPLATE("variants: values", T, D1, X1, D2, X2) {


### PR DESCRIPTION
## Problem

`m_size` only means anything when `TSize` is `Dynamic`. For every other variant it was eight bytes that nothing reads — and the constructor taking `Data` never set them, which is what clang-tidy reported in #80:

```
hyperjet.h:322: 1 uninitialized field at the end of the constructor call
                [clang-analyzer-optin.cplusplus.UninitializedObject]
  322 |   DDScalar(const Data &data) : m_data(data) {
   56 |   index m_size;   <- uninitialized
```

Nothing read the field, so nothing was visibly wrong. But every copy of such an object copied an indeterminate value, which is UB to read and would trip MSan.

## Change

The field gets an empty stand-in type for the static variants, marked `[[no_unique_address]]` (`[[msvc::no_unique_address]]` on MSVC, which still needs the vendor spelling). A static scalar is now exactly its data:

| | before | after |
|---|---|---|
| `DDScalar<1, double, 3>` | 40 | **32** |
| `DDScalar<2, double, 3>` | 88 | **80** |
| `DDScalar<2, double, 8>` | 368 | **360** |
| `DDScalar<2, double, 16>` | 1232 | **1224** |
| `DDScalar<2, double, Dynamic>` | 32 | 32 |

The initializer-list constructor is the one place that runs for both variants *and* set the field from its member initializer list. It now computes the size into a local and only stores it when there is somewhere to store it.

## Why this matters beyond the lint

This settles the layout question a NumPy dtype asks of its element type. A static scalar is now payload-sized and trivially copyable; the dynamic one is neither — which is the concrete reason only the static variants could ever back a dtype. Eight bytes per element of dead weight would otherwise have been an uninitialized byte range *inside* every array element, plus 10 % wasted bandwidth on the hot path for size 3.

## Not a performance change — measured, not assumed

Five alternating runs of `a * b + a.sin()` over 20k elements, `-O3 -DNDEBUG`:

| | main | this branch |
|---|---|---|
| size 3 | 10.81 · 10.85 · 10.86 · 10.92 · 13.27¹ | 10.74 · 10.81 · 10.91 · 10.93 · 11.00 |
| size 8 | 52.04 · 52.11 · 52.22 · 52.47 · 52.89 | 51.60 · 51.84 · 51.87 · 51.91 · 52.41 |

¹ first run, cold start

Size 3 unchanged; size 8 consistently a little faster in all five runs — the smaller object pays off marginally. Worth recording: my **first** measurement showed 17.96 → 20.12 ns and looked like a 12 % regression. It was cold-start noise, and repeating it is what showed that.

## Verification

- **C++ 102 test cases, 1310 assertions** — Release with `-Werror`, and under clang with ASan+UBSan
- **Python 172 passed**; exported API dump identical against a build of the previous state
- **clang-tidy 51 → 50 findings**, the uninitialized field gone, 0 errors

`TEST_CASE("Static scalars are exactly their data")` pins it: `sizeof(T) == sizeof(T::Data)` for sizes 0, 3 and 8 across both orders, trivial copyability and standard layout for the static variants, and `CHECK_FALSE(is_trivially_copyable_v<...>)` for the dynamic one. RED was 4 of its 8 checks failing.

## Notes

Based on `main`. Independent of #81 (binding codegen, still open) — that one touches `python/`, this one `include/`.

Next in the sequence we discussed: the NumPy dtype itself, once #81 lands.
