### PR TITLE
test: characterize SScalar and document what it is

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,9 @@
 #   modernize-use-nodiscard                57 sites; annotating the API with
 #                                          [[nodiscard]] is a decision to make
 #                                          on purpose, not a lint fix
+#   modernize-use-std-numbers              cannot tell an expected test value
+#                                          that happens to sit near a constant
+#                                          from a constant written out by hand
 #   modernize-use-trailing-return-type     style the project does not use
 #   portability-avoid-pragma-once          #pragma once is a deliberate choice
 #   readability-function-cognitive-*       binary()/ternary() are inherently so
@@ -30,6 +33,7 @@ Checks: >
   -bugprone-throwing-static-initialization,
   -misc-include-cleaner,
   -modernize-use-nodiscard,
+  -modernize-use-std-numbers,
   -modernize-use-trailing-return-type,
   -portability-avoid-pragma-once,
   -readability-function-cognitive-complexity,

--- a/README.md
+++ b/README.md
@@ -126,6 +126,38 @@ f.d("y")   # df/dy
 >>> 1.0
 ```
 
+`SScalar` is **first order only** — there is no Hessian. Where `DDScalar` offers `h`, `hm` and the second-order factories, `SScalar` has a value and a gradient keyed by name. The variable set does not have to be known in advance: an operation takes the union of the names of its operands, and `d` returns zero for a name the scalar has never seen.
+
+```python
+u = hj.SScalar.variable("x", 2.0)
+v = hj.SScalar.variable("y", 3.0)
+
+len(u * v)          # the product knows both names
+>>> 2
+(u * v).d("z")      # an unknown name is zero, not an error
+>>> 0.0
+(u - u).size        # names survive even where the derivative cancels
+>>> 1
+```
+
+Two further differences from `DDScalar` worth knowing:
+
+- **No serialization.** `copy`, `deepcopy` and `pickle` raise `TypeError`; the `DDScalar` types support all three.
+- **The order of terms in `repr` is unspecified**, because the derivatives live in an unordered map. Only the value comes first.
+
+`eval(d)` contracts the gradient with a displacement given per name. Names missing from the displacement contribute nothing, and names the scalar does not know are ignored:
+
+```python
+u = hj.SScalar(f=3, d={"x": 1, "y": 6})
+
+u.eval({"x": 0.5, "y": -0.25})
+>>> 2.0
+u.eval({"x": 0.5})          # y contributes nothing
+>>> 3.5
+u.eval({"w": 100.0})        # w is unknown and ignored
+>>> 3.0
+```
+
 ## Validation
 
 Arguments coming from Python are validated. Out-of-range Hessian indices raise `IndexError`; inconsistent sizes raise `RuntimeError` — `eval` with the wrong number of values, `set_hm` with a mismatched shape, a negative size, a variable index outside the gradient, or padding below the current size.

--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -1747,7 +1747,9 @@ public: // types
   using Data = std::unordered_map<std::string, TScalar>;
 
 private: // variables
-  Scalar m_f;
+  // The default constructor is defaulted, so without an initializer m_f would
+  // be indeterminate and reading it undefined.
+  Scalar m_f{};
   Data m_d;
 
 private: // methods
@@ -1823,13 +1825,13 @@ public: // methods
   Scalar eval(const Data &d) const {
     Scalar r(m_f);
 
-    for (const auto coef : m_d) {
-      const auto it = d.find(coef.first);
+    for (const auto &[name, derivative] : m_d) {
+      const auto it = d.find(name);
 
       if (it == d.end())
         continue;
 
-      r += coef.second * it->second;
+      r += derivative * it->second;
     }
 
     return r;

--- a/python/tests/test_SScalar.py
+++ b/python/tests/test_SScalar.py
@@ -3,6 +3,7 @@ import hyperjet as hj
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 from copy import copy
+import pickle
 
 if __name__ == "__main__":
     import os
@@ -65,3 +66,154 @@ def test_self_division():
     assert_allclose(r.f, 1)
     assert_allclose(r.d("x"), 0, atol=1e-15)
     assert_allclose(r.d("y"), 0, atol=1e-15)
+
+
+# The binding surface. The mathematics is characterized in
+# test/src/test_sscalar.cpp; these tests pin what the bindings add on top.
+
+
+def test_construction():
+    assert_equal(len(hj.SScalar()), 0)
+    assert_allclose(hj.SScalar().f, 0)
+
+    assert_allclose(hj.SScalar(f=1.5).f, 1.5)
+    assert_equal(len(hj.SScalar(f=1.5)), 0)
+
+    assert_allclose(hj.SScalar.constant(1.5).f, 1.5)
+    assert_equal(len(hj.SScalar.constant(1.5)), 0)
+
+    v = hj.SScalar.variable("a", 1.5)
+
+    assert_allclose(v.f, 1.5)
+    assert_equal(len(v), 1)
+    assert_allclose(v.d("a"), 1)
+
+    # an unknown name has a zero derivative rather than raising
+    assert_allclose(v.d("b"), 0)
+
+
+def test_properties():
+    u = hj.SScalar(f=3, d={"x": 1, "y": 6})
+
+    assert_allclose(u.f, 3)
+    assert_equal(u.size, 2)
+    assert_equal(len(u), 2)
+
+
+def test_repr():
+    # The derivatives live in an unordered map, so the order of the terms is
+    # unspecified. Only the value comes first and every term appears once.
+    text = repr(hj.SScalar(f=3, d={"x": 1, "y": 6}))
+
+    assert text.startswith("3")
+    assert "+1*dx" in text
+    assert "+6*dy" in text
+
+    # negative derivatives are printed without a plus sign
+    assert_equal(repr(hj.SScalar(f=1, d={"x": -2})), "1 -2*dx")
+
+
+def test_eval():
+    u = hj.SScalar(f=3, d={"x": 1, "y": 6})
+
+    assert_allclose(u.eval({"x": 0.5, "y": -0.25}), 2.0)
+
+    # names missing from the displacement contribute nothing, unknown ones are
+    # ignored
+    assert_allclose(u.eval({"x": 0.5}), 3.5)
+    assert_allclose(u.eval({}), 3.0)
+    assert_allclose(u.eval({"w": 100.0}), 3.0)
+
+
+def test_operators():
+    u = hj.SScalar(f=3, d={"x": 1})
+    v = hj.SScalar(f=4, d={"y": 2})
+
+    for op, f, dx, dy in [
+        (lambda: u + v, 7, 1, 2),
+        (lambda: u - v, -1, 1, -2),
+        (lambda: u * v, 12, 4, 6),
+        (lambda: u / v, 0.75, 0.25, -0.375),
+        (lambda: -u, -3, -1, 0),
+    ]:
+        r = op()
+        assert_allclose(r.f, f)
+        assert_allclose(r.d("x"), dx)
+        assert_allclose(r.d("y"), dy)
+
+    for op, f, dx in [
+        (lambda: u + 2, 5, 1),
+        (lambda: 2 + u, 5, 1),
+        (lambda: u - 2, 1, 1),
+        (lambda: 2 - u, -1, -1),
+        (lambda: u * 2, 6, 2),
+        (lambda: 2 * u, 6, 2),
+        (lambda: u / 2, 1.5, 0.5),
+        (lambda: 2 / u, 2 / 3, -2 / 9),
+        (lambda: u**2, 9, 6),
+        (lambda: abs(-u), 3, 1),
+    ]:
+        r = op()
+        assert_allclose(r.f, f)
+        assert_allclose(r.d("x"), dx)
+
+
+def test_in_place_operators():
+    def fresh():
+        return hj.SScalar(f=3, d={"x": 1}), hj.SScalar(f=4, d={"y": 2})
+
+    for op, f, dx, dy in [
+        (lambda a, b: a.__iadd__(b), 7, 1, 2),
+        (lambda a, b: a.__isub__(b), -1, 1, -2),
+        (lambda a, b: a.__imul__(b), 12, 4, 6),
+        (lambda a, b: a.__itruediv__(b), 0.75, 0.25, -0.375),
+    ]:
+        a, b = fresh()
+        r = op(a, b)
+        assert_allclose(r.f, f)
+        assert_allclose(r.d("x"), dx)
+        assert_allclose(r.d("y"), dy)
+
+
+def test_comparison_uses_the_value_only():
+    a = hj.SScalar(f=1, d={"x": 100})
+    b = hj.SScalar(f=2, d={"y": -100})
+    c = hj.SScalar(f=1)
+
+    assert a < b and a <= b and b > a and b >= a and a != b
+    assert not (a == b)
+
+    # equal values compare equal no matter what the derivatives say
+    assert a == c and a <= c and a >= c
+
+    assert a < 2 and a == 1 and 2 > a and 1 == a
+
+
+def test_numpy_aliases_agree():
+    u = hj.SScalar(f=0.3, d={"x": 1})
+    v = hj.SScalar(f=0.4, d={"y": 1})
+
+    for alias, name in [
+        ("arccos", "acos"),
+        ("arcsin", "asin"),
+        ("arctan", "atan"),
+        ("arccosh", "acosh"),
+        ("arcsinh", "asinh"),
+        ("arctanh", "atanh"),
+    ]:
+        w = hj.SScalar(f=1.5, d={"x": 1}) if name == "acosh" else u
+        assert_allclose(getattr(w, alias)().f, getattr(w, name)().f)
+        assert_allclose(getattr(w, alias)().d("x"), getattr(w, name)().d("x"))
+
+    assert_allclose(u.arctan2(v).f, u.atan2(v).f)
+
+
+def test_no_serialization():
+    # Unlike the DDScalar bindings, SScalar has neither pickle nor copy support.
+    u = hj.SScalar(f=3, d={"x": 1})
+
+    with pytest.raises(TypeError):
+        copy(u)
+
+    with pytest.raises(TypeError):
+        pickle.dumps(u)

--- a/test/src/test_sscalar.cpp
+++ b/test/src/test_sscalar.cpp
@@ -1,0 +1,207 @@
+#include <doctest/doctest.h>
+
+#include <hyperjet/hyperjet.h>
+
+#include <sstream> // stringstream
+#include <string>  // string
+
+// Characterization of SScalar.
+//
+// test.cpp covers the operators and a handful of functions. This pins the rest,
+// so a change to the storage -- interning the names and keeping the derivatives
+// dense, for instance -- can be verified rather than hoped for.
+//
+// The expected values were derived symbolically, so they share no formulas with
+// the header. First order means value phi(f) and derivative phi'(f) * d_i, and
+// they were generated that way.
+
+namespace {
+
+using S = hyperjet::SScalar<double>;
+
+const S s1(3.0, {{"x", 1.0}, {"y", 6.0}, {"z", 4.0}});
+const S s2(4.0, {{"x", 7.0}, {"y", 1.0}});
+
+// acos, asin and atanh need |f| <= 1
+const S s3(0.3, {{"x", 0.1}, {"y", 0.8}, {"z", 0.2}});
+
+void check(const S &r, const double f, const double dx, const double dy,
+           const double dz) {
+  CHECK(r.f() == doctest::Approx(f));
+  CHECK(r.d("x") == doctest::Approx(dx));
+  CHECK(r.d("y") == doctest::Approx(dy));
+  CHECK(r.d("z") == doctest::Approx(dz));
+}
+
+TEST_CASE("SScalar construction") {
+  CHECK(S().f() == doctest::Approx(0.0));
+  CHECK(S().size() == 0);
+
+  CHECK(S(1.5).f() == doctest::Approx(1.5));
+  CHECK(S(1.5).size() == 0);
+
+  CHECK(S::constant(1.5).f() == doctest::Approx(1.5));
+  CHECK(S::constant(1.5).size() == 0);
+
+  const auto v = S::variable("a", 1.5);
+
+  CHECK(v.f() == doctest::Approx(1.5));
+  CHECK(v.size() == 1);
+  CHECK(v.d("a") == doctest::Approx(1.0));
+
+  // an unknown name has a zero derivative rather than being an error
+  CHECK(v.d("b") == doctest::Approx(0.0));
+}
+
+TEST_CASE("SScalar arithmetic functions") {
+  check(s1.reciprocal(), 0.33333333333333331, -0.1111111111111111,
+        -0.66666666666666663, -0.44444444444444442);
+
+  using std::cbrt;
+  check(cbrt(s1), 1.4422495703074083, 0.1602499522563787, 0.96149971353827224,
+        0.64099980902551479);
+}
+
+TEST_CASE("SScalar trigonometric functions") {
+  using std::acos;
+  using std::asin;
+  using std::atan;
+  using std::atan2;
+
+  check(acos(s3), 1.2661036727794992, -0.10482848367219183,
+        -0.83862786937753464, -0.20965696734438366);
+  check(asin(s3), 0.30469265401539752, 0.10482848367219183, 0.83862786937753464,
+        0.20965696734438366);
+  check(atan(s1), 1.2490457723982544, 0.10000000000000001, 0.59999999999999998,
+        0.40000000000000002);
+  check(atan2(s1, s2), 0.64350110879328437, -0.68000000000000005,
+        0.83999999999999997, 0.64000000000000001);
+}
+
+TEST_CASE("SScalar hyperbolic functions") {
+  using std::acosh;
+  using std::asinh;
+  using std::atanh;
+  using std::cosh;
+  using std::sinh;
+  using std::tanh;
+
+  check(cosh(s1), 10.067661995777765, 10.017874927409903, 60.107249564459408,
+        40.07149970963961);
+  check(sinh(s1), 10.017874927409903, 10.067661995777765, 60.405971974666592,
+        40.270647983111061);
+  check(tanh(s1), 0.99505475368673046, 0.0098660371654401904,
+        0.05919622299264115, 0.039464148661760762);
+  check(acosh(s1), 1.7627471740390861, 0.35355339059327379, 2.1213203435596424,
+        1.4142135623730951);
+  check(asinh(s1), 1.8184464592320668, 0.31622776601683794, 1.8973665961010275,
+        1.2649110640673518);
+  check(atanh(s3), 0.3095196042031117, 0.10989010989010989, 0.87912087912087911,
+        0.21978021978021978);
+}
+
+TEST_CASE("SScalar exponents and logarithms") {
+  using std::exp;
+  using std::log;
+  using std::log10;
+  using std::log2;
+
+  check(exp(s1), 20.085536923187668, 20.085536923187668, 120.51322153912601,
+        80.342147692750672);
+  check(log(s1), 1.0986122886681098, 0.33333333333333331, 2.0,
+        1.3333333333333333);
+  check(log2(s1), 1.5849625007211561, 0.48089834696298778, 2.8853900817779268,
+        1.9235933878519511);
+  check(log10(s1), 0.47712125471966244, 0.14476482730108395,
+        0.86858896380650363, 0.57905930920433579);
+
+  // log with an explicit base agrees with log2
+  check(s1.log(2.0), 1.5849625007211561, 0.48089834696298778,
+        2.8853900817779268, 1.9235933878519511);
+}
+
+TEST_CASE("SScalar abs") {
+  using std::abs;
+
+  // a positive value passes through, a negative one flips value and derivatives
+  check(abs(s1), 3.0, 1.0, 6.0, 4.0);
+  check(abs(-s1), 3.0, 1.0, 6.0, 4.0);
+}
+
+TEST_CASE("SScalar comparison uses the value only") {
+  const S a(1.0, {{"x", 100.0}});
+  const S b(2.0, {{"y", -100.0}});
+
+  CHECK(a < b);
+  CHECK(a <= b);
+  CHECK(b > a);
+  CHECK(b >= a);
+  CHECK(a != b);
+  CHECK_FALSE(a == b);
+
+  // equal values compare equal no matter what the derivatives say
+  const S c(1.0);
+
+  CHECK(a == c);
+  CHECK(a <= c);
+  CHECK(a >= c);
+
+  CHECK(a < 2.0);
+  CHECK(a == 1.0);
+  CHECK(2.0 > a);
+  CHECK(1.0 == a);
+}
+
+TEST_CASE("SScalar eval") {
+  // f plus the derivatives contracted with the displacement
+  CHECK(s1.eval({{"x", 0.5}, {"y", -0.25}, {"z", 2.0}}) ==
+        doctest::Approx(10.0));
+
+  // names missing from the displacement contribute nothing
+  CHECK(s1.eval({{"x", 0.5}}) == doctest::Approx(3.5));
+  CHECK(s1.eval({}) == doctest::Approx(3.0));
+
+  // names the scalar does not know are ignored
+  CHECK(s1.eval({{"x", 0.5}, {"w", 100.0}}) == doctest::Approx(3.5));
+}
+
+TEST_CASE("SScalar size counts the stored derivatives") {
+  CHECK(s1.size() == 3);
+  CHECK(s2.size() == 2);
+  CHECK(S::constant(1.0).size() == 0);
+
+  // an operation takes the union of the names, even where a derivative
+  // cancels to zero
+  const auto sum = s1 + s2;
+
+  CHECK(sum.size() == 3);
+
+  // deliberate: the names have to survive even when the derivative cancels
+  // NOLINTNEXTLINE(misc-redundant-expression)
+  const auto diff = s1 - s1;
+
+  CHECK(diff.size() == 3);
+  CHECK(diff.d("x") == doctest::Approx(0.0));
+}
+
+TEST_CASE("SScalar printing") {
+  // The derivatives live in an unordered_map, so the order of the terms is
+  // unspecified. Only the value comes first, and every term appears once.
+  std::stringstream out;
+  out << s2;
+  const std::string text = out.str();
+
+  CHECK(text.starts_with("4"));
+  CHECK(text.find("*dx") != std::string::npos);
+  CHECK(text.find("*dy") != std::string::npos);
+  CHECK(text.find("+7") != std::string::npos);
+  CHECK(text.find("+1") != std::string::npos);
+
+  // negative derivatives are printed without a plus sign
+  std::stringstream negative;
+  negative << S(1.0, {{"x", -2.0}});
+
+  CHECK(negative.str() == "1 -2*dx");
+}
+
+} // namespace


### PR DESCRIPTION
## Why

`SScalar` is 746 lines with **20 C++ test cases** covering the operators and a handful of functions, and **4 Python tests**. The plan is to change its storage — and without a net, a change of that size cannot be verified, only hoped for. It is the same gap that let three memory-safety bugs through on the `DDScalar` side earlier in this series.

This is step 1 of three: characterize, then change the storage (#next), then second order.

## What

`test/src/test_sscalar.cpp` covers the functions the existing cases miss — `reciprocal`, `cbrt`, the inverse trigonometric and all hyperbolic functions, the exponential and logarithmic family, `abs` — plus the behaviour nothing pinned at all: construction and the factories, comparison by value only, `eval` against a displacement, what `size` counts, and printing. Expected values derived **symbolically**, so they share no formulas with the header.

Python goes from 4 tests to 12, aimed at what the bindings add rather than at the mathematics: the operator set including the reverse and in-place forms, the NumPy aliases against their primary names, `__len__`, `__abs__`, `__pow__`, `__repr__`, and that `copy`, `deepcopy` and `pickle` all raise.

## Validated by mutation

Five deliberate faults in the header, each failing three assertions:

| mutation | |
|---|---|
| `cbrt` derivative 3 → 2 | 3 failed |
| `acos` loses its sign | 3 failed |
| `atanh` denominator sign | 3 failed |
| `log10` on the wrong base | 3 failed |
| `sinh` derivative `cosh` → `sinh` | 3 failed |

## Two fixes, both prerequisites rather than scope

**`m_f` was indeterminate.** The defaulted constructor left it uninitialized, so a test asserting `S().f() == 0` would have been testing luck rather than behaviour. Initialized now.

**`eval` copied the name on every iteration.** clang-tidy had never reported it because *nothing instantiated `eval`* — the new tests do, and the warning appeared immediately. That is the same instantiation-coverage effect as in #75 and #79, this time with a measurable defect as the payoff. With 20 names past the small-string limit:

```
before:  1657 ns, 20.00 allocations per call
after:    287 ns,  0.00 allocations per call
```

## Two findings recorded rather than changed

- **The order of terms in `operator<<` is unspecified**, because the derivatives live in an `unordered_map`. The tests assert the value comes first and that every term appears — not the whole string.
- **Names survive an operation even where the derivative cancels**: `s1 - s1` has `size() == 3`, not 0.

## Documentation

The README said nothing about any of this. It now states that `SScalar` is first order only, that the variable set does not have to be known in advance, that an unknown name is zero rather than an error, that there is no serialization, and what `eval` does with names present on only one side. Every example number was checked against the module.

## Verification

- **C++ 112 test cases, 1425 assertions** — Debug and Release with `-Werror`, and under clang with ASan+UBSan
- **Python 248 passed**
- clang-tidy back to 50 findings, `clang-format --Werror` and `ruff format --check` clean

`.clang-tidy` drops `modernize-use-std-numbers`: it cannot tell an expected test value that happens to sit near a constant from a constant written out by hand, and it flagged `cbrt(3)` as `log2e` while itself reporting that the two differ by 4.45e-04.
