### PR TITLE
fix: let the accessors be called on a temporary

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -356,9 +356,14 @@ public:
 
   static constexpr index order() { return TOrder; }
 
-  auto &data(this auto &self) { return self.m_data; }
+  // The object parameter is a forwarding reference so that a result can be
+  // read straight from the expression that produced it: an lvalue reference
+  // would not bind to a temporary, and (a * b).f() would not compile. As with
+  // std::vector::operator[], a reference obtained from a temporary is only
+  // valid within the full expression.
+  auto &data(this auto &&self) { return self.m_data; }
 
-  auto ptr(this auto &self) { return self.m_data.data(); }
+  auto ptr(this auto &&self) { return self.m_data.data(); }
 
   static constexpr index static_size() { return TSize; }
 
@@ -607,11 +612,11 @@ public:
     }
   }
 
-  auto &f(this auto &self) { return self.m_data[0]; }
+  auto &f(this auto &&self) { return self.m_data[0]; }
 
   void set_f(const Scalar value) { m_data[0] = value; }
 
-  auto &g(this auto &self, const index i) {
+  auto &g(this auto &&self, const index i) {
     assert(0 <= i && i < self.size());
 
     return self.m_data[1 + i];
@@ -619,7 +624,7 @@ public:
 
   void set_g(const index i, const Scalar value) { g(i) = value; }
 
-  auto &h(this auto &self, const index i)
+  auto &h(this auto &&self, const index i)
     requires(order() == 2)
   {
     assert(0 <= i && i < self.size() * (self.size() + 1) / 2);
@@ -633,7 +638,7 @@ public:
     h(i) = value;
   }
 
-  auto &h(this auto &self, const index i, const index j)
+  auto &h(this auto &&self, const index i, const index j)
     requires(order() == 2)
   {
     assert(0 <= i && i < self.size());

--- a/test/src/test_variants.cpp
+++ b/test/src/test_variants.cpp
@@ -5,7 +5,9 @@
 #include <hyperjet/hyperjet.h>
 
 #include <array>       // array
+#include <cmath>       // exp, sin
 #include <type_traits> // is_trivially_copyable
+#include <utility>     // move
 #include <vector>      // vector
 
 // Coverage across all four combinations of order and sizing.
@@ -110,6 +112,57 @@ void check(const T &actual, const std::vector<double> &expected) {
 // A statically sized scalar is exactly its data. The runtime size is only
 // meaningful for the dynamic variant, where it also rules out trivial copying.
 // Both properties are what an element type has to offer a NumPy dtype.
+
+// A result has to be readable straight from the expression that produced it.
+// The accessors take their object by deducing this, and an lvalue reference
+// parameter cannot bind to a temporary.
+
+template <typename T>
+concept ReadsValue = requires(T a) { std::move(a).f(); };
+
+template <typename T>
+concept ReadsGradient = requires(T a) { std::move(a).g(index{0}); };
+
+template <typename T>
+concept ReadsHessian = requires(T a) { std::move(a).h(index{0}, index{0}); };
+
+template <typename T>
+concept ReadsData = requires(T a) { std::move(a).data(); };
+
+template <typename T>
+concept ReadsPointer = requires(T a) { std::move(a).ptr(); };
+
+TEST_CASE_TEMPLATE("variants: a temporary can be read from", T, D1, X1, D2,
+                   X2) {
+  CHECK(ReadsValue<T>);
+  CHECK(ReadsGradient<T>);
+  CHECK(ReadsData<T>);
+  CHECK(ReadsPointer<T>);
+
+  if constexpr (T::order() == 2) {
+    CHECK(ReadsHessian<T>);
+  }
+
+  // and the values read from a temporary are the right ones
+  const auto a = make<T>(A);
+  const auto b = make<T>(B);
+
+  CHECK((a * b).f() == doctest::Approx(MulAB[0]));
+  CHECK((a * b).g(0) == doctest::Approx(MulAB[1]));
+  CHECK((a * b).g(1) == doctest::Approx(MulAB[2]));
+  CHECK(sqrt(a).f() == doctest::Approx(SqrtA[0]));
+  CHECK(sqrt(a).data()[0] == doctest::Approx(SqrtA[0]));
+  CHECK(*(a + b).ptr() == doctest::Approx(AddAB[0]));
+
+  if constexpr (T::order() == 2) {
+    CHECK((a * b).h(0, 0) == doctest::Approx(MulAB[3]));
+    CHECK((a * b).h(0, 1) == doctest::Approx(MulAB[4]));
+    CHECK((a * b).h(0) == doctest::Approx(MulAB[3]));
+  }
+
+  // a chained read, which is what makes this worth fixing
+  CHECK(a.sin().exp().f() == doctest::Approx(std::exp(std::sin(A[0]))));
+}
 
 TEST_CASE("Static scalars are exactly their data") {
   CHECK(sizeof(DDScalar<1, double, 0>) == sizeof(DDScalar<1, double, 0>::Data));


### PR DESCRIPTION
## Problem

The accessors take their object by deducing `this`, declared as an **lvalue** reference — which cannot bind to a temporary. So a result could not be read from the expression that produced it:

```cpp
(a * b).f()        // error: candidate function not viable:
sqrt(a).g(0)       //        expects an lvalue for object argument
a.sin().h(0, 0)
```

Every C++ caller had to introduce a named variable for every intermediate result. Six accessors were affected: `data`, `ptr`, `f`, `g`, `h(i)` and `h(i, j)`.

This came in with the deducing-`this` refactor of the C++23 modernisation, which replaced the duplicated const/non-const overload pairs. The old pairs had a const overload that bound to temporaries; the single deducing-`this` version does not.

## Fix

The object parameter becomes a forwarding reference — `this auto &&self` instead of `this auto &self` — which binds to lvalues, const lvalues and temporaries alike. One character per accessor.

`SScalar` is unaffected: its `f()` and `d()` return by value.

## Caveat, and it is documented in the header

As with `std::vector::operator[]`, a reference obtained from a temporary is only valid within the full expression:

```cpp
const auto &r = (a * a).f();   // dangles, and no compiler diagnoses it
```

I checked: `-Wall -Wextra -Wpedantic` emits nothing for that. The note sits where the accessors are declared.

## What did not change

The writable path: `result.f() = value` on an lvalue still works — the factories rely on it — and so does reading through a const lvalue. Verified separately as well as by the suite.

## Tests

The property is stated twice over.

**Callability**, as concepts over all four combinations of order and sizing — 18 assertions, all of which failed before the change:

```
test_variants.cpp:135: ERROR: CHECK( ReadsValue<T> ) is NOT correct!
test_variants.cpp:136: ERROR: CHECK( ReadsGradient<T> ) is NOT correct!
test_variants.cpp:137: ERROR: CHECK( ReadsData<T> ) is NOT correct!
test_variants.cpp:138: ERROR: CHECK( ReadsPointer<T> ) is NOT correct!
test_variants.cpp:141: ERROR: CHECK( ReadsHessian<T> ) is NOT correct!
```

Deliberately expressed as concepts rather than as direct calls, so the red state is a failing assertion rather than a build error.

**Values**, read from temporaries and compared against the expectations the surrounding cases already use — including a chained read, `a.sin().exp().f()`, which is the case that makes this worth fixing at all.

## Verification

- **C++ 106 test cases, 1362 assertions** — Debug and Release with `-Werror`, and under clang with ASan+UBSan
- **Python 239 passed**
- clang-tidy unchanged at 50; `clang-format --Werror` and `ruff format --check` clean

## Notes

Independent of #84 and #85 — this touches `DDScalar`'s accessors, those two touch `SScalar`. Based on `main`, merges in any order.

Found while measuring for the `SScalar` work: a benchmark of mine would not compile, and the compiler error turned out to be a defect in the library rather than in the benchmark.
