### PR TITLE
refactor: template SScalar on the derivative order

### DIFF
--- a/include/hyperjet/hyperjet.h
+++ b/include/hyperjet/hyperjet.h
@@ -1746,9 +1746,14 @@ log10(const DDScalar<TOrder, TScalar, TSize> &a) {
   return a.log10();
 }
 
-template <typename TScalar> class SScalar {
+// Derivatives keyed by name rather than by index. The variable set does not
+// have to be known in advance: an operation takes the union of the names of its
+// operands. Second order is not implemented yet, hence the constraint.
+template <index TOrder, typename TScalar = double>
+  requires(TOrder == 1)
+class SScalar {
 public: // types
-  using Type = SScalar<TScalar>;
+  using Type = SScalar<TOrder, TScalar>;
   using Scalar = TScalar;
 
   // The interface type for construction and eval. A map is what callers, and
@@ -2341,147 +2346,170 @@ public: // methods
 
 // std::abs
 
-template <typename TScalar> SScalar<TScalar> abs(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> abs(const SScalar<TOrder, TScalar> &a) {
   return a.abs();
 }
 
 // std::pow
 
-template <typename TScalar>
-SScalar<TScalar> pow(const SScalar<TScalar> &a, const index b) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> pow(const SScalar<TOrder, TScalar> &a, const index b) {
   return a.pow(b);
 }
 
-template <typename TScalar>
-SScalar<TScalar> pow(const SScalar<TScalar> &a, const TScalar b) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> pow(const SScalar<TOrder, TScalar> &a,
+                             const TScalar b) {
   return a.pow(b);
 }
 
 // std::sqrt
 
-template <typename TScalar> SScalar<TScalar> sqrt(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> sqrt(const SScalar<TOrder, TScalar> &a) {
   return a.sqrt();
 }
 
 // std::cbrt
 
-template <typename TScalar> SScalar<TScalar> cbrt(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> cbrt(const SScalar<TOrder, TScalar> &a) {
   return a.cbrt();
 }
 
 // std::cos
 
-template <typename TScalar> SScalar<TScalar> cos(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> cos(const SScalar<TOrder, TScalar> &a) {
   return a.cos();
 }
 
 // std::sin
 
-template <typename TScalar> SScalar<TScalar> sin(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> sin(const SScalar<TOrder, TScalar> &a) {
   return a.sin();
 }
 
 // std::tan
 
-template <typename TScalar> SScalar<TScalar> tan(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> tan(const SScalar<TOrder, TScalar> &a) {
   return a.tan();
 }
 
 // std::acos
 
-template <typename TScalar> SScalar<TScalar> acos(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> acos(const SScalar<TOrder, TScalar> &a) {
   return a.acos();
 }
 
 // std::asin
 
-template <typename TScalar> SScalar<TScalar> asin(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> asin(const SScalar<TOrder, TScalar> &a) {
   return a.asin();
 }
 
 // std::atan
 
-template <typename TScalar> SScalar<TScalar> atan(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> atan(const SScalar<TOrder, TScalar> &a) {
   return a.atan();
 }
 
 // std::atan2
 
-template <typename TScalar>
-SScalar<TScalar> atan2(const SScalar<TScalar> &a, const SScalar<TScalar> &b) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> atan2(const SScalar<TOrder, TScalar> &a,
+                               const SScalar<TOrder, TScalar> &b) {
   return a.atan2(b);
 }
 
 // std::hypot
 
-template <typename TScalar>
-SScalar<TScalar> hypot(const SScalar<TScalar> &a, const SScalar<TScalar> &b) {
-  return SScalar<TScalar>::hypot(a, b);
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> hypot(const SScalar<TOrder, TScalar> &a,
+                               const SScalar<TOrder, TScalar> &b) {
+  return SScalar<TOrder, TScalar>::hypot(a, b);
 }
 
-template <typename TScalar>
-SScalar<TScalar> hypot(const SScalar<TScalar> &a, const SScalar<TScalar> &b,
-                       const SScalar<TScalar> &c) {
-  return SScalar<TScalar>::hypot(a, b, c);
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> hypot(const SScalar<TOrder, TScalar> &a,
+                               const SScalar<TOrder, TScalar> &b,
+                               const SScalar<TOrder, TScalar> &c) {
+  return SScalar<TOrder, TScalar>::hypot(a, b, c);
 }
 
 // std::cosh
 
-template <typename TScalar> SScalar<TScalar> cosh(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> cosh(const SScalar<TOrder, TScalar> &a) {
   return a.cosh();
 }
 
 // std::sinh
 
-template <typename TScalar> SScalar<TScalar> sinh(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> sinh(const SScalar<TOrder, TScalar> &a) {
   return a.sinh();
 }
 
 // std::tanh
 
-template <typename TScalar> SScalar<TScalar> tanh(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> tanh(const SScalar<TOrder, TScalar> &a) {
   return a.tanh();
 }
 
 // std::acosh
 
-template <typename TScalar> SScalar<TScalar> acosh(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> acosh(const SScalar<TOrder, TScalar> &a) {
   return a.acosh();
 }
 
 // std::asin
 
-template <typename TScalar> SScalar<TScalar> asinh(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> asinh(const SScalar<TOrder, TScalar> &a) {
   return a.asinh();
 }
 
 // std::atan
 
-template <typename TScalar> SScalar<TScalar> atanh(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> atanh(const SScalar<TOrder, TScalar> &a) {
   return a.atanh();
 }
 
 // std::exp
 
-template <typename TScalar> SScalar<TScalar> exp(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> exp(const SScalar<TOrder, TScalar> &a) {
   return a.exp();
 }
 
 // std::log
 
-template <typename TScalar> SScalar<TScalar> log(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> log(const SScalar<TOrder, TScalar> &a) {
   return a.log();
 }
 
 // std::log2
 
-template <typename TScalar> SScalar<TScalar> log2(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> log2(const SScalar<TOrder, TScalar> &a) {
   return a.log2();
 }
 
 // std::log10
 
-template <typename TScalar> SScalar<TScalar> log10(const SScalar<TScalar> &a) {
+template <index TOrder, typename TScalar>
+SScalar<TOrder, TScalar> log10(const SScalar<TOrder, TScalar> &a) {
   return a.log10();
 }
 

--- a/python/src/bind_sscalar.cpp
+++ b/python/src/bind_sscalar.cpp
@@ -1,7 +1,7 @@
 #include "common.h"
 
 void bind_sscalar(pybind11::module &m) {
-  using T = hj::SScalar<double>;
+  using T = hj::SScalar<1, double>;
 
   auto cls = py::class_<T>(m, "SScalar");
 

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -627,12 +627,12 @@ TEST_CASE("Dynamic size checks") {
   CHECK_THROWS_AS(b.hm("full", out_too_small), std::runtime_error);
 }
 
-const SScalar<double> s1(3.0, {{"x", 1.0}, {"y", 6.0}, {"z", 4.0}});
-const SScalar<double> s2(4.0, {{"x", 7.0}, {"y", 1.0}});
-const SScalar<double> s3(0.3, {{"x", 0.1}, {"y", 0.8}, {"z", 0.2}});
+const SScalar<1, double> s1(3.0, {{"x", 1.0}, {"y", 6.0}, {"z", 4.0}});
+const SScalar<1, double> s2(4.0, {{"x", 7.0}, {"y", 1.0}});
+const SScalar<1, double> s3(0.3, {{"x", 0.1}, {"y", 0.8}, {"z", 0.2}});
 
 TEST_CASE("SScalar init") {
-  using Dual = SScalar<double>;
+  using Dual = SScalar<1, double>;
 
   const auto x = Dual(1.5, {{"x", 2.0}, {"y", 1.0}});
 
@@ -646,7 +646,7 @@ TEST_CASE("SScalar init") {
 }
 
 TEST_CASE("SScalar constant") {
-  using Dual = SScalar<double>;
+  using Dual = SScalar<1, double>;
 
   const auto x = Dual::constant(1.5);
 
@@ -659,7 +659,7 @@ TEST_CASE("SScalar constant") {
 }
 
 TEST_CASE("SScalar variable") {
-  using Dual = SScalar<double>;
+  using Dual = SScalar<1, double>;
 
   const auto x = Dual::variable("x", 1.5);
 

--- a/test/src/test_sscalar.cpp
+++ b/test/src/test_sscalar.cpp
@@ -17,7 +17,7 @@
 
 namespace {
 
-using S = hyperjet::SScalar<double>;
+using S = hyperjet::SScalar<1, double>;
 
 const S s1(3.0, {{"x", 1.0}, {"y", 6.0}, {"z", 4.0}});
 const S s2(4.0, {{"x", 7.0}, {"y", 1.0}});


### PR DESCRIPTION
Groundwork for named second-order derivatives. On its own this changes no behaviour — it makes room for one.

## What

`SScalar<TScalar>` becomes `SScalar<TOrder, TScalar>`, mirroring `DDScalar`, where the order is the first template parameter and the Python name carries one letter per order — `DScalar` and `DDScalar`.

The constraint is `requires(TOrder == 1)`: second order is not implemented in this PR, so `SScalar<2, double>` is a clear constraint violation rather than a silent instantiation that would compute a zero Hessian.

```
error: constraints not satisfied for class template 'SScalar' [with TOrder = 2, TScalar = double]
note: because '2L == 1' (2 == 1) evaluated to false
```

Mechanical throughout: 25 template heads and 55 type uses in the header, one site in the bindings, seven in the tests. No behaviour change, which the characterization suite from #84 confirms without a single expected value being touched.

## The C++ spelling changes

`hyperjet::SScalar<double>` becomes `hyperjet::SScalar<1, double>`. Putting the order first is what makes the two class templates consistent. The alternative — ordering it `<TScalar, TOrder>` so the old spelling keeps working — would have left the library with two different conventions for the same concept. The Python name `hj.SScalar` is unchanged.

## Verification

- **C++ 106 test cases, 1473 assertions** — Debug with `-Werror`
- **Python 248 passed**, `hj.SScalar` still exposes the same 35 methods
- `clang-format --Werror` clean

## Where this is going

Second order is a dense triangular Hessian over the sorted names from #85 — the position of a name in that vector is the index the Hessian is laid out over. The design is settled and the groundwork done:

- `merge_names` produces the union in one pass and records where each operand's names land, which is what the Hessian has to be scattered along
- the accumulation is taken verbatim in the shape `DDScalar` uses, where 1473 assertions already cover it
- all 24 second-order coefficients were extracted from the corresponding `DDScalar` functions rather than transcribed by hand

Not in this PR, and deliberately so. A first attempt at wiring the 29 call sites used a script that collected all regex matches up front and then replaced them sequentially; after the first replacement the later search strings no longer existed, and `str.replace` became a silent no-op. It reported `atan2` as converted when it was not. Left unnoticed, that would have shipped functions returning a **silently zero Hessian** — the worst failure mode for an AD library, since it computes rather than crashes.

So the follow-up writes symbolically generated second-order expectations for all 24 functions *before* the conversion, so a missed one fails a test instead of nothing at all.